### PR TITLE
reduce UPDATE statement

### DIFF
--- a/inc/acf-functions.php
+++ b/inc/acf-functions.php
@@ -210,11 +210,11 @@ function mpd_do_acf_images_to_destination($post_id){
 
                             array_push($attach_ids,$attach_id);
 
-                            update_field($acf_gallerys[$gallery_key]['field'], $attach_ids, $post_id);
-
                         }
                         
                     }
+                   
+                    update_field($acf_gallerys[$gallery_key]['field'], $attach_ids, $post_id);
 
                 }
                 


### PR DESCRIPTION
It seems that "update_field" function is called each time copying image in gallery.
To change this line, it is possible to reduce unnecessary UPDATE statements.